### PR TITLE
Unowned Back References

### DIFF
--- a/Sources/CodableDatastore/Persistence/Disk Persistence/Snapshot/Snapshot.swift
+++ b/Sources/CodableDatastore/Persistence/Disk Persistence/Snapshot/Snapshot.swift
@@ -20,7 +20,7 @@ actor Snapshot<AccessMode: _AccessMode> {
     /// The persistence the stapshot is a part of.
     ///
     /// Prefer to access ``Snapshot/persistence`` instead, which offers non-optional access to the same persistence.
-    private weak var _persistence: DiskPersistence<AccessMode>?
+    unowned let persistence: DiskPersistence<AccessMode>
     
     /// A flag indicating if this is a backup snapshot.
     ///
@@ -39,23 +39,15 @@ actor Snapshot<AccessMode: _AccessMode> {
         isBackup: Bool = false
     ) {
         self.id = id
-        self._persistence = persistence
+        self.persistence = persistence
         self.isBackup = isBackup
-    }
-}
-
-extension Snapshot {
-    @inlinable
-    var persistence: DiskPersistence<AccessMode> {
-        guard let persistence = _persistence else { preconditionFailure("Persistence is no longer allocated for this snapshot.") }
-        return persistence
     }
 }
 
 // MARK: - Common URL Accessors
 extension Snapshot {
     /// The URL that points to the Snapshot directory.
-    var snapshotURL: URL {
+    nonisolated var snapshotURL: URL {
         guard let components = try? id.components else { preconditionFailure("Components could not be determined for Snapshot.") }
         
         let baseURL = isBackup ? persistence.backupsURL : persistence.snapshotsURL
@@ -68,22 +60,22 @@ extension Snapshot {
     }
     
     /// The URL that points to the Manifest.json file.
-    var manifestURL: URL {
+    nonisolated var manifestURL: URL {
         snapshotURL.appendingPathComponent("Manifest.json", isDirectory: false)
     }
     
     /// The URL that points to the Dirty file.
-    var dirtyURL: URL {
+    nonisolated var dirtyURL: URL {
         snapshotURL.appendingPathComponent("Dirty", isDirectory: false)
     }
     
     /// The URL that points to the Datastores directory.
-    var datastoresURL: URL {
+    nonisolated var datastoresURL: URL {
         snapshotURL.appendingPathComponent("Datastores", isDirectory: true)
     }
     
     /// The URL that points to the Inbox directory.
-    var inboxURL: URL {
+    nonisolated var inboxURL: URL {
         snapshotURL.appendingPathComponent("Inbox", isDirectory: true)
     }
 }

--- a/Tests/CodableDatastoreTests/SnapshotTests.swift
+++ b/Tests/CodableDatastoreTests/SnapshotTests.swift
@@ -52,7 +52,7 @@ final class SnapshotTests: XCTestCase {
         XCTAssertTrue(isEmpty)
         
         let snapshot = Snapshot(id: SnapshotIdentifier.mockIdentifier, persistence: persistence, isBackup: false)
-        let snapshotURL = await snapshot.snapshotURL
+        let snapshotURL = snapshot.snapshotURL
         XCTAssertEqual(snapshotURL.absoluteString, temporaryStoreURL.absoluteString.appending("Snapshots/1970/01-02/03-04/1970-01-02%2003-04-05%200123456789ABCDEF.snapshot/"))
         XCTAssertThrowsError(try snapshotURL.checkResourceIsReachable())
     }
@@ -64,7 +64,7 @@ final class SnapshotTests: XCTestCase {
         
         try await snapshot.withManifest { _ in }
         
-        let snapshotURL = await snapshot.snapshotURL
+        let snapshotURL = snapshot.snapshotURL
         XCTAssertEqual(snapshotURL.absoluteString, temporaryStoreURL.absoluteString.appending("Snapshots/1970/01-02/03-04/1970-01-02%2003-04-05%200123456789ABCDEF.snapshot/"))
         
         XCTAssertTrue(try snapshotURL.checkResourceIsReachable())
@@ -88,7 +88,7 @@ final class SnapshotTests: XCTestCase {
         let persistence = try DiskPersistence(readWriteURL: temporaryStoreURL)
         let snapshot = Snapshot(id: SnapshotIdentifier.mockIdentifier, persistence: persistence, isBackup: false)
         try await snapshot.withManifest { _ in }
-        let snapshotURL = await snapshot.snapshotURL
+        let snapshotURL = snapshot.snapshotURL
         
         let data = try Data(contentsOf: snapshotURL.appendingPathComponent("Manifest.json", isDirectory: false))
         
@@ -120,7 +120,7 @@ final class SnapshotTests: XCTestCase {
         let persistence = try DiskPersistence(readWriteURL: temporaryStoreURL)
         let snapshot = Snapshot(id: SnapshotIdentifier.mockIdentifier, persistence: persistence, isBackup: false)
         try await snapshot.withManifest { _ in }
-        let snapshotURL = await snapshot.snapshotURL
+        let snapshotURL = snapshot.snapshotURL
         
         let dataBefore = try Data(contentsOf: snapshotURL.appendingPathComponent("Manifest.json", isDirectory: false))
         // This second time should be a no-op and shouldn't throw


### PR DESCRIPTION
Updated the back-reference from a snapshot to a persistence to be unowned instead of weak.