### PR TITLE
On Demand Datastore Descriptors

### DIFF
--- a/Sources/CodableDatastore/Persistence/Memory Persistence/MemoryPersistence.swift
+++ b/Sources/CodableDatastore/Persistence/Memory Persistence/MemoryPersistence.swift
@@ -19,6 +19,12 @@ extension MemoryPersistence: _Persistence {
         preconditionFailure("Unimplemented")
     }
     
+    public func datastoreDescriptor<V, C, I, A>(
+        for datastore: Datastore<V, C, I, A>
+    ) async throws -> DatastoreDescriptor? {
+        preconditionFailure("Unimplemented")
+    }
+    
     public func withTransaction(_ transaction: (MemoryPersistence) -> ()) async throws {
         preconditionFailure("Unimplemented")
     }

--- a/Sources/CodableDatastore/Persistence/Persistence.swift
+++ b/Sources/CodableDatastore/Persistence/Persistence.swift
@@ -19,6 +19,8 @@ public protocol Persistence<AccessMode>: _Persistence {
 public protocol _Persistence {
     func register<Version, CodedType, IdentifierType, AccessMode>(datastore: Datastore<Version, CodedType, IdentifierType, AccessMode>) async throws -> DatastoreDescriptor?
     
+    func datastoreDescriptor<Version, CodedType, IdentifierType, AccessMode>(for datastore: Datastore<Version, CodedType, IdentifierType, AccessMode>) async throws -> DatastoreDescriptor?
+    
     func withTransaction(_ transaction: (_ persistence: Self) -> ()) async throws
 }
 


### PR DESCRIPTION
Added new method to Persistence for loading a datastore descriptor at any time.