### PR TITLE
DatastorePageEntry Decoding Tests

### DIFF
--- a/Sources/CodableDatastore/Persistence/Disk Persistence/Datastore/DatastorePageEntry.swift
+++ b/Sources/CodableDatastore/Persistence/Disk Persistence/Datastore/DatastorePageEntry.swift
@@ -27,8 +27,11 @@ extension DatastorePageEntry {
         let space = " ".utf8Bytes[0]
         let newline = "\n".utf8Bytes[0]
         
-        /// First, check for a new line. If we get one, the header section is done.
-        while let nextByte = iterator.next(), nextByte != newline {
+        repeat {
+            /// First, check for a new line. If we get one, the header section is done.
+            let nextByte = try iterator.next(Bytes.self, count: 1)[0]
+            guard nextByte != newline else { break }
+            
             /// Accumulate the following bytes until we encounter a space
             var headerSizeBytes = [nextByte]
             while let nextByte = iterator.next(), nextByte != space {
@@ -45,7 +48,7 @@ extension DatastorePageEntry {
             
             /// Make sure it ends in a new line
             try iterator.check(utf8: "\n")
-        }
+        } while true
         
         /// Just collect the rest of the bytes as the content.
         self.content = iterator.next(Bytes.self, max: bytes.count)

--- a/Sources/CodableDatastore/Persistence/Disk Persistence/DiskPersistenceError.swift
+++ b/Sources/CodableDatastore/Persistence/Disk Persistence/DiskPersistenceError.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A ``DiskPersistence``-specific error.
-public enum DiskPersistenceError: LocalizedError {
+public enum DiskPersistenceError: LocalizedError, Equatable {
     /// The specified URL for the persistence store is not a file URL.
     case notFileURL
     

--- a/Tests/CodableDatastoreTests/DatastorePageEntryTests.swift
+++ b/Tests/CodableDatastoreTests/DatastorePageEntryTests.swift
@@ -1,0 +1,241 @@
+//
+//  DatastorePageEntryTests.swift
+//  CodableDatastore
+//
+//  Created by Dimitri Bouniol on 2023-07-04.
+//  Copyright © 2023 Mochi Development, Inc. All rights reserved.
+//
+
+import XCTest
+@testable import CodableDatastore
+import Bytes
+
+final class DatastorePageEntryTests: XCTestCase {
+    func testDecoding() {
+        XCTAssertEqual(
+            try DatastorePageEntry(
+                bytes: """
+                
+                
+                """.utf8Bytes,
+                isPartial: false
+            ),
+            DatastorePageEntry(headers: [], content: [])
+        )
+        
+        XCTAssertEqual(
+            try DatastorePageEntry(
+                bytes: """
+                
+                A
+                """.utf8Bytes,
+                isPartial: false
+            ),
+            DatastorePageEntry(headers: [], content: "A".utf8Bytes)
+        )
+        
+        XCTAssertEqual(
+            try DatastorePageEntry(
+                bytes: """
+                1 \u{1}
+                
+                A
+                """.utf8Bytes,
+                isPartial: false
+            ),
+            DatastorePageEntry(headers: [[1]], content: "A".utf8Bytes)
+        )
+        
+        XCTAssertEqual(
+            try DatastorePageEntry(
+                bytes: """
+                1 \u{1}
+                
+                
+                """.utf8Bytes,
+                isPartial: false
+            ),
+            DatastorePageEntry(headers: [[1]], content: [])
+        )
+        
+        XCTAssertEqual(
+            try DatastorePageEntry(
+                bytes: """
+                1 \u{1}
+                2 \u{2}\u{2}
+                3 \u{3}\u{3}\u{3}
+                
+                A
+                """.utf8Bytes,
+                isPartial: false
+            ),
+            DatastorePageEntry(headers: [[1], [2, 2], [3, 3, 3]], content: "A".utf8Bytes)
+        )
+        
+        XCTAssertEqual(
+            try DatastorePageEntry(
+                bytes: """
+                1 \u{1}
+                16 A complex
+                string
+                3 \u{3}\u{3}\u{3}
+                
+                Some complex
+                content
+                """.utf8Bytes,
+                isPartial: false
+            ),
+            DatastorePageEntry(headers: [[1], "A complex\nstring".utf8Bytes, [3, 3, 3]], content: "Some complex\ncontent".utf8Bytes)
+        )
+        
+        XCTAssertThrowsError(
+            try DatastorePageEntry(
+                bytes: """
+                 
+                """.utf8Bytes,
+                isPartial: false
+            )
+        ) { error in
+            XCTAssertEqual(error as? DiskPersistenceError, .invalidEntryFormat)
+        }
+        
+        XCTAssertThrowsError(
+            try DatastorePageEntry(
+                bytes: """
+                A
+                """.utf8Bytes,
+                isPartial: false
+            )
+        ) { error in
+            XCTAssertEqual(error as? DiskPersistenceError, .invalidEntryFormat)
+        }
+        
+        XCTAssertThrowsError(
+            try DatastorePageEntry(
+                bytes: """
+                1
+                """.utf8Bytes,
+                isPartial: false
+            )
+        ) { error in
+            switch error {
+            case BytesError.invalidMemorySize(targetSize: 1, targetType: _, actualSize: 0): break
+            default:
+                XCTFail("Unknown error \(error)")
+            }
+        }
+        
+        XCTAssertThrowsError(
+            try DatastorePageEntry(
+                bytes: """
+                1 1
+                """.utf8Bytes,
+                isPartial: false
+            )
+        ) { error in
+            switch error {
+            case BytesError.checkedSequenceNotFound: break
+            default:
+                XCTFail("Unknown error \(error)")
+            }
+        }
+        
+        XCTAssertThrowsError(
+            try DatastorePageEntry(
+                bytes: """
+                1\u{20}
+                
+                
+                """.utf8Bytes,
+                isPartial: false
+            )
+        ) { error in
+            switch error {
+            case BytesError.invalidMemorySize(targetSize: 1, targetType: _, actualSize: 0): break
+            default:
+                XCTFail("Unknown error \(error)")
+            }
+        }
+        
+        XCTAssertThrowsError(
+            try DatastorePageEntry(
+                bytes: """
+                0\u{20}
+                
+                
+                """.utf8Bytes,
+                isPartial: false
+            )
+        ) { error in
+            XCTAssertEqual(error as? DiskPersistenceError, .invalidEntryFormat)
+        }
+        
+        XCTAssertThrowsError(
+            try DatastorePageEntry(
+                bytes: """
+                1 1
+                
+                """.utf8Bytes,
+                isPartial: false
+            )
+        ) { error in
+            switch error {
+            case BytesError.invalidMemorySize(targetSize: 1, targetType: _, actualSize: 0): break
+            default:
+                XCTFail("Unknown error \(error)")
+            }
+        }
+    }
+    
+    func testEncoding() {
+        XCTAssertEqual(
+            DatastorePageEntry(headers: [], content: []).bytes,
+            """
+            
+            
+            """.utf8Bytes
+        )
+        
+        XCTAssertEqual(
+            DatastorePageEntry(headers: [], content: "A".utf8Bytes).bytes,
+            """
+            
+            A
+            """.utf8Bytes
+        )
+        
+        XCTAssertEqual(
+            DatastorePageEntry(headers: [[1]], content: "A".utf8Bytes).bytes,
+            """
+            1 \u{1}
+            
+            A
+            """.utf8Bytes
+        )
+        
+        XCTAssertEqual(
+            DatastorePageEntry(headers: [[1], [2, 2], [3, 3, 3]], content: "A".utf8Bytes).bytes,
+            """
+            1 \u{1}
+            2 \u{2}\u{2}
+            3 \u{3}\u{3}\u{3}
+            
+            A
+            """.utf8Bytes
+        )
+        
+        XCTAssertEqual(
+            DatastorePageEntry(headers: [[1], "A complex\nstring".utf8Bytes, [3, 3, 3]], content: "Some complex\ncontent".utf8Bytes).bytes,
+            """
+            1 \u{1}
+            16 A complex
+            string
+            3 \u{3}\u{3}\u{3}
+            
+            Some complex
+            content
+            """.utf8Bytes
+        )
+    }
+    
+}


### PR DESCRIPTION
Fixed an issue decoding partial entries when the header could be incomplete.