### PR TITLE
Don't Be Lazy

### DIFF
--- a/Sources/CodableDatastore/Persistence/Disk Persistence/Datastore/DatastoreIndexManifest.swift
+++ b/Sources/CodableDatastore/Persistence/Disk Persistence/Datastore/DatastoreIndexManifest.swift
@@ -24,7 +24,7 @@ struct DatastoreIndexManifest: Equatable, Identifiable {
     
     /// Pointers to the pageIDs currently in use by the index.
     var orderedPageIDs: some Sequence<DatastorePageIdentifier> {
-        orderedPages.lazy.compactMap { pageInfo -> DatastorePageIdentifier? in
+        orderedPages.compactMap { pageInfo -> DatastorePageIdentifier? in
             if case .removed = pageInfo { return nil }
             
             return pageInfo.id


### PR DESCRIPTION
Improve performance writing to the datastore by 2× at 10k writes, though it is still exponential in some way due to the filter.