### PR TITLE
Unsafe Transaction Options

### DIFF
--- a/Sources/CodableDatastore/Persistence/TransactionOptions.swift
+++ b/Sources/CodableDatastore/Persistence/TransactionOptions.swift
@@ -10,18 +10,45 @@ import Foundation
 
 /// A set of options that the caller of a transaction can specify.
 public struct TransactionOptions: OptionSet {
-    public let rawValue: Int
+    public let rawValue: UInt64
     
-    public init(rawValue: Int) {
-        self.rawValue = rawValue
+    public init(rawValue: UInt64) {
+        self.rawValue = rawValue & 0b00000111
     }
     
     /// The transaction is read only, and can be performed concurrently with other transactions.
-    public static let readOnly = TransactionOptions(rawValue: 1 << 0)
+    public static let readOnly = Self(rawValue: 1 << 0)
     
     /// The transaction can return before it has successfully written to disk, allowing subsequent writes to be queued and written all at once. If an error occurs when it is time to actually persist the changes, the state of the persistence will not reflect the changes made in a transaction.
-    public static let collateWrites = TransactionOptions(rawValue: 1 << 1)
+    public static let collateWrites = Self(rawValue: 1 << 1)
     
     /// The transaction is idempotent and does not modify any other kind of state, and can be retried when it encounters an inconsistency. This allows a transaction to concurrently operate with other writes, which may be necessary in a disptributed environment.
-    public static let idempotent = TransactionOptions(rawValue: 1 << 2)
+    public static let idempotent = Self(rawValue: 1 << 2)
+}
+
+/// A set of options that the caller of a transaction can specify.
+///
+/// These options are generally unsafe to use improperly, and should generally not be used.
+public struct UnsafeTransactionOptions: OptionSet {
+    public let rawValue: UInt64
+    
+    public init(rawValue: UInt64) {
+        self.rawValue = rawValue
+    }
+    
+    public init(_ transactionOptions: TransactionOptions) {
+        self.rawValue = transactionOptions.rawValue
+    }
+    
+    /// The transaction is read only, and can be performed concurrently with other transactions.
+    public static let readOnly = Self(.readOnly)
+    
+    /// The transaction can return before it has successfully written to disk, allowing subsequent writes to be queued and written all at once. If an error occurs when it is time to actually persist the changes, the state of the persistence will not reflect the changes made in a transaction.
+    public static let collateWrites = Self(.collateWrites)
+    
+    /// The transaction is idempotent and does not modify any other kind of state, and can be retried when it encounters an inconsistency. This allows a transaction to concurrently operate with other writes, which may be necessary in a disptributed environment.
+    public static let idempotent = Self(.idempotent)
+    
+    /// The transaction should skip emitting observations. This is useful when the transaction must enumerate and modify the entire data set, which would cause each modified entry to be kept in memory for the duration of the transaction.
+    public static let skipObservations = Self(rawValue: 1 << 16)
 }

--- a/Tests/CodableDatastoreTests/TransactionOptionsTests.swift
+++ b/Tests/CodableDatastoreTests/TransactionOptionsTests.swift
@@ -1,0 +1,90 @@
+//
+//  TransactionOptionsTests.swift
+//  CodableDatastore
+//
+//  Created by Dimitri Bouniol on 2023-07-12.
+//  Copyright © 2023 Mochi Development, Inc. All rights reserved.
+//
+
+import XCTest
+import CodableDatastore
+
+final class TransactionOptionsTests: XCTestCase {
+    func assertTransactionOptions(
+        options: TransactionOptions,
+        expectedRawValue: UInt64,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(options.rawValue, expectedRawValue, file: file, line: line)
+    }
+    
+    func testTransactionOptions() {
+        assertTransactionOptions(options: [], expectedRawValue: 0)
+        
+        assertTransactionOptions(options: .readOnly, expectedRawValue: 1)
+        assertTransactionOptions(options: .collateWrites, expectedRawValue: 2)
+        assertTransactionOptions(options: .idempotent, expectedRawValue: 4)
+        
+        assertTransactionOptions(options: [.readOnly, .collateWrites], expectedRawValue: 3)
+        assertTransactionOptions(options: [.readOnly, .idempotent], expectedRawValue: 5)
+        assertTransactionOptions(options: [.collateWrites, .idempotent], expectedRawValue: 6)
+        
+        assertTransactionOptions(options: [.readOnly, .collateWrites, .idempotent], expectedRawValue: 7)
+    }
+    
+    func testInvalidTransactionOptions() {
+        assertTransactionOptions(options: TransactionOptions(rawValue: 8), expectedRawValue: 0)
+        assertTransactionOptions(options: TransactionOptions(rawValue: 9), expectedRawValue: 1)
+        assertTransactionOptions(options: TransactionOptions(rawValue: 10), expectedRawValue: 2)
+        assertTransactionOptions(options: TransactionOptions(rawValue: 11), expectedRawValue: 3)
+    }
+}
+
+final class UnsafeTransactionOptionsTests: XCTestCase {
+    func assertUnsafeTransactionOptions(
+        options: UnsafeTransactionOptions,
+        expectedRawValue: UInt64,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(options.rawValue, expectedRawValue, file: file, line: line)
+    }
+    
+    func testUnsafeTransactionOptions() {
+        assertUnsafeTransactionOptions(options: [], expectedRawValue: 0)
+        
+        assertUnsafeTransactionOptions(options: .readOnly, expectedRawValue: 1)
+        assertUnsafeTransactionOptions(options: .collateWrites, expectedRawValue: 2)
+        assertUnsafeTransactionOptions(options: .idempotent, expectedRawValue: 4)
+        assertUnsafeTransactionOptions(options: .skipObservations, expectedRawValue: 65536)
+        
+        assertUnsafeTransactionOptions(options: [.readOnly, .collateWrites], expectedRawValue: 3)
+        assertUnsafeTransactionOptions(options: [.readOnly, .idempotent], expectedRawValue: 5)
+        assertUnsafeTransactionOptions(options: [.readOnly, .skipObservations], expectedRawValue: 65537)
+        assertUnsafeTransactionOptions(options: [.collateWrites, .idempotent], expectedRawValue: 6)
+        assertUnsafeTransactionOptions(options: [.collateWrites, .skipObservations], expectedRawValue: 65538)
+        assertUnsafeTransactionOptions(options: [.idempotent, .skipObservations], expectedRawValue: 65540)
+        
+        assertUnsafeTransactionOptions(options: [.readOnly, .collateWrites, .idempotent], expectedRawValue: 7)
+        assertUnsafeTransactionOptions(options: [.readOnly, .collateWrites, .skipObservations], expectedRawValue: 65539)
+        assertUnsafeTransactionOptions(options: [.readOnly, .idempotent, .skipObservations], expectedRawValue: 65541)
+        assertUnsafeTransactionOptions(options: [.collateWrites, .idempotent, .skipObservations], expectedRawValue: 65542)
+        
+        assertUnsafeTransactionOptions(options: [.readOnly, .collateWrites, .idempotent, .skipObservations], expectedRawValue: 65543)
+    }
+    
+    func testConvertedTransactionOptions() {
+        assertUnsafeTransactionOptions(options: UnsafeTransactionOptions(TransactionOptions([])), expectedRawValue: 0)
+        
+        assertUnsafeTransactionOptions(options: UnsafeTransactionOptions(TransactionOptions.readOnly), expectedRawValue: 1)
+        assertUnsafeTransactionOptions(options: UnsafeTransactionOptions(TransactionOptions.collateWrites), expectedRawValue: 2)
+        assertUnsafeTransactionOptions(options: UnsafeTransactionOptions(TransactionOptions.idempotent), expectedRawValue: 4)
+        
+        assertUnsafeTransactionOptions(options: UnsafeTransactionOptions(TransactionOptions([.readOnly, .collateWrites])), expectedRawValue: 3)
+        assertUnsafeTransactionOptions(options: UnsafeTransactionOptions(TransactionOptions([.readOnly, .idempotent])), expectedRawValue: 5)
+        assertUnsafeTransactionOptions(options: UnsafeTransactionOptions(TransactionOptions([.collateWrites, .idempotent])), expectedRawValue: 6)
+        
+        assertUnsafeTransactionOptions(options: UnsafeTransactionOptions(TransactionOptions([.readOnly, .collateWrites, .idempotent])), expectedRawValue: 7)
+    }
+}


### PR DESCRIPTION
Added unsafe transaction options, including one to skip observations.