### PR TITLE
Persistence Datastore Actor Durability

### DIFF
--- a/Sources/CodableDatastore/Persistence/Disk Persistence/DiskPersistence.swift
+++ b/Sources/CodableDatastore/Persistence/Disk Persistence/DiskPersistence.swift
@@ -420,7 +420,9 @@ extension DiskPersistence {
         if let self = self as? DiskPersistence<ReadWrite> {
             let (datastore, rootID) = try await self.withCurrentSnapshot { snapshot in
                 try await snapshot.withManifest { snapshotManifest in
-                    await snapshot.loadDatastore(for: datastoreKey, from: snapshotManifest)
+                    let (datastore, root) = await snapshot.loadDatastore(for: datastoreKey, from: snapshotManifest)
+                    snapshotManifest.dataStores[datastoreKey.rawValue] = .init(key: datastoreKey.rawValue, id: datastore.id, root: root)
+                    return (datastore, root)
                 }
             }
             return (datastore as! DiskPersistence<AccessMode>.Datastore, rootID)

--- a/Sources/CodableDatastore/Persistence/Disk Persistence/Snapshot/SnapshotManifest.swift
+++ b/Sources/CodableDatastore/Persistence/Disk Persistence/Snapshot/SnapshotManifest.swift
@@ -38,6 +38,6 @@ extension SnapshotManifest {
         var id: DatastoreIdentifier
         
         /// The root object for the datastore.
-        var root: DatastoreRootIdentifier
+        var root: DatastoreRootIdentifier?
     }
 }


### PR DESCRIPTION
Fixed an issue where multiple datastores could be created before the first write to a persistence.