### PR TITLE
Load From Disk

### DIFF
--- a/Sources/CodableDatastore/Persistence/Disk Persistence/Snapshot/Snapshot.swift
+++ b/Sources/CodableDatastore/Persistence/Disk Persistence/Snapshot/Snapshot.swift
@@ -329,6 +329,6 @@ extension Snapshot {
         let datastore = DiskPersistence<AccessMode>.Datastore(id: datastoreInfo.id, snapshot: self)
         datastores[datastoreInfo.id] = datastore
         
-        return (datastore, nil)
+        return (datastore, datastoreInfo.root)
     }
 }


### PR DESCRIPTION
Fixed an issue where the datastore root would be lost when loading a persistence from disk.