### PR TITLE
Format Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Please check the [releases](https://github.com/mochidev/CodableDatastore/release
 dependencies: [
     .package(
         url: "https://github.com/mochidev/CodableDatastore.git", 
-        .upToNextMinor(from: "0.2.0")
+        .upToNextMinor(from: "0.2.1")
     ),
 ],
 ...

--- a/Sources/CodableDatastore/Datastore/DatastoreFormat.swift
+++ b/Sources/CodableDatastore/Datastore/DatastoreFormat.swift
@@ -182,5 +182,5 @@ extension DatastoreFormat {
 //}
 
 extension DatastoreFormat where Instance: Identifiable, Instance.ID: Indexable & DiscreteIndexable {
-    typealias Identifier = Instance.ID
+    public typealias Identifier = Instance.ID
 }

--- a/Sources/CodableDatastore/Datastore/DatastoreFormat.swift
+++ b/Sources/CodableDatastore/Datastore/DatastoreFormat.swift
@@ -176,6 +176,14 @@ extension DatastoreFormat {
     }
 }
 
+extension DatastoreFormat {
+    /// A typealias of the read-write datastore this format describes.
+    public typealias Datastore = CodableDatastore.Datastore<Self, ReadWrite>
+    
+    /// A typealias of the read-only datastore this format describes.
+    public typealias ReadOnlyDatastore = CodableDatastore.Datastore<Self, ReadOnly>
+}
+
 //extension DatastoreFormat where Instance: Identifiable, Instance.ID: Indexable & DiscreteIndexable, Self.Identifier == Instance.ID {
 //    @available(*, unavailable, message: "id is reserved on Identifiable Instance types.")
 //    var id: Never { preconditionFailure("id is reserved on Identifiable Instance types.") }


### PR DESCRIPTION
- Added a more complete DatastoreFormat example.
- Added public typealiases for the Datastore types on the format.
- Fixed an issue where the Identifier type was not marked as public.