### PR TITLE
Transaction Race Corruption

### DIFF
--- a/Sources/CodableDatastore/Persistence/Disk Persistence/Transaction/Transaction.swift
+++ b/Sources/CodableDatastore/Persistence/Disk Persistence/Transaction/Transaction.swift
@@ -137,6 +137,10 @@ extension DiskPersistence {
             }
             
             if let parent {
+                /// If the transaction is read-only, stop here without applying anything to the parent.
+                guard !options.contains(.readOnly) else {
+                    return
+                }
                 try await parent.apply(
                     rootObjects: rootObjects,
                     entryMutations: entryMutations,


### PR DESCRIPTION
- Fixed a race that could occur where a long running read-only transaction could overwrite writes that just occurred.
- Added assertions to ensure read-only transactions don't process mutations accidentally.