### PR TITLE
Better UUID Comparable Conformance

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Please check the [releases](https://github.com/mochidev/CodableDatastore/release
 dependencies: [
     .package(
         url: "https://github.com/mochidev/CodableDatastore.git", 
-        .upToNextMinor(from: "0.3.2")
+        .upToNextMinor(from: "0.3.3")
     ),
 ],
 ...

--- a/Sources/CodableDatastore/Indexes/UUID+Comparable.swift
+++ b/Sources/CodableDatastore/Indexes/UUID+Comparable.swift
@@ -8,11 +8,12 @@
 
 import Foundation
 
+/// Make UUIDs comparable on platforms that shipped without it, so that they can be used transparently as an index.
 #if swift(<5.9) || os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Windows)
-/// Make UUIDs comparable, so that they can be used transparently as an index.
 #if compiler(>=6)
 extension UUID: @retroactive Comparable {
     @inlinable
+    @_disfavoredOverload
     public static func < (lhs: UUID, rhs: UUID) -> Bool {
         lhs.isLessThan(rhs: rhs)
     }
@@ -20,6 +21,7 @@ extension UUID: @retroactive Comparable {
 #else
 extension UUID: Comparable {
     @inlinable
+    @_disfavoredOverload
     public static func < (lhs: UUID, rhs: UUID) -> Bool {
         lhs.isLessThan(rhs: rhs)
     }


### PR DESCRIPTION
On packages that target the latest SDKs, Comparable conformance is already present, thus leading to ambiguity. This should hopefully address that when the operator is used directly.