### PR TITLE
Disk Persistence Retain Cycle

### DIFF
--- a/Sources/CodableDatastore/Persistence/Disk Persistence/Transaction/Transaction.swift
+++ b/Sources/CodableDatastore/Persistence/Disk Persistence/Transaction/Transaction.swift
@@ -11,7 +11,7 @@ import Bytes
 
 extension DiskPersistence {
     actor Transaction: AnyDiskTransaction {
-        let persistence: DiskPersistence
+        unowned let persistence: DiskPersistence
         
         unowned let parent: Transaction?
         var childTransactions: [Transaction] = []


### PR DESCRIPTION
Fixed a retain cycle that could prevent a DiskPersistence from deinitializing when no longer used.