### PR TITLE
Flip Migration Arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ struct BookStore: DatastoreFormat {
             // version, and convert it to the modern type you use in the app.
             // Conversions are typically only done at read time.
             migrations: [
-                .v1: { data, decoder in try Book(decoder.decode(BookV1.self, from: data)) },
-                .current: { data, decoder in try decoder.decode(Book.self, from: data) }
+                .v1: { try Book($0.decode(BookV1.self, from: $1)) },
+                .current: { try $0.decode(Book.self, from: $1) }
             ]
         )
     }

--- a/Sources/CodableDatastore/Datastore/DatastoreFormat.swift
+++ b/Sources/CodableDatastore/Datastore/DatastoreFormat.swift
@@ -45,8 +45,8 @@ import Foundation
 ///         .JSONStore(
 ///             persistence: persistence,
 ///             migrations: [
-///                 .v1: { data, decoder in try Book(decoder.decode(BookV1.self, from: data)) },
-///                 .current: { data, decoder in try decoder.decode(Book.self, from: data) }
+///                 .v1: { try Book($0.decode(BookV1.self, from: $1)) },
+///                 .current: { try $0.decode(Book.self, from: $1) }
 ///             ]
 ///         )
 ///     }

--- a/Tests/CodableDatastoreTests/DiskPersistenceDatastoreTests.swift
+++ b/Tests/CodableDatastoreTests/DiskPersistenceDatastoreTests.swift
@@ -49,9 +49,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             persistence: persistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -87,9 +85,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             persistence: persistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -125,9 +121,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             persistence: persistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -165,9 +159,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             persistence: persistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -201,9 +193,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             persistence: persistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -237,9 +227,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
                 persistence: persistence,
                 format: TestFormat.self,
                 migrations: [
-                    .zero: { data, decoder in
-                        try decoder.decode(TestFormat.Instance.self, from: data)
-                    }
+                    .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
                 ]
             )
             
@@ -262,9 +250,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             key: "test",
             version: .zero,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         let count = try await datastore.count
@@ -303,9 +289,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             persistence: persistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -343,9 +327,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             persistence: persistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -391,9 +373,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             persistence: persistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -439,9 +419,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             persistence: persistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -493,9 +471,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             persistence: persistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -551,9 +527,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             persistence: persistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -648,9 +622,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             persistence: persistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -702,9 +674,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             persistence: persistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -758,9 +728,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             persistence: persistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -815,9 +783,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             persistence: persistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -877,9 +843,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             persistence: persistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -937,9 +901,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             persistence: persistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -1014,9 +976,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
             persistence: persistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -1094,9 +1054,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
                 persistence: persistence,
                 format: TestFormat.self,
                 migrations: [
-                    .zero: { data, decoder in
-                        try decoder.decode(TestFormat.Instance.self, from: data)
-                    }
+                    .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
                 ]
             )
             
@@ -1125,9 +1083,7 @@ final class DiskPersistenceDatastoreTests: XCTestCase, @unchecked Sendable {
                 persistence: persistence,
                 format: TestFormat.self,
                 migrations: [
-                    .zero: { data, decoder in
-                        try decoder.decode(TestFormat.Instance.self, from: data)
-                    }
+                    .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
                 ]
             )
             

--- a/Tests/CodableDatastoreTests/MultiplePersistenceTests.swift
+++ b/Tests/CodableDatastoreTests/MultiplePersistenceTests.swift
@@ -48,9 +48,7 @@ final class MultiplePersistenceTests: XCTestCase, @unchecked Sendable {
             persistence: outerPersistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         
@@ -58,9 +56,7 @@ final class MultiplePersistenceTests: XCTestCase, @unchecked Sendable {
             persistence: innerPersistence,
             format: TestFormat.self,
             migrations: [
-                .zero: { data, decoder in
-                    try decoder.decode(TestFormat.Instance.self, from: data)
-                }
+                .zero: { try $0.decode(TestFormat.Instance.self, from: $1) }
             ]
         )
         


### PR DESCRIPTION
Flipped the `data` and `decoder` migration arguments to make writing them more natural.

Fixed #177